### PR TITLE
Fixed reference to non-existing member variable graph.node in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ for (s,e) in graph.edges():
     plt.plot(ps[:,1], ps[:,0], 'green')
     
 # draw node by o
-node, nodes = graph.node, graph.nodes()
-ps = np.array([node[i]['o'] for i in nodes])
+nodes = graph.nodes()
+ps = np.array([nodes[i]['o'] for i in nodes])
 plt.plot(ps[:,1], ps[:,0], 'r.')
 
 # title and show

--- a/sknw/__init__.py
+++ b/sknw/__init__.py
@@ -19,8 +19,8 @@ def test():
         ps = graph[s][e]['pts']
         plt.plot(ps[:,1], ps[:,0], 'green')
 
-    node, nodes = graph.node, graph.nodes()
-    ps = np.array([node[i]['o'] for i in nodes])
+    nodes = graph.nodes()
+    ps = np.array([nodes[i]['o'] for i in nodes])
     plt.plot(ps[:,1], ps[:,0], 'r.')
     plt.title('Build Graph')
     plt.show()


### PR DESCRIPTION
Makes example easier to follow, since it doesn't run without this change.