### PR TITLE
try to overpass int16 restriction on image size

### DIFF
--- a/sknw/sknw.py
+++ b/sknw/sknw.py
@@ -25,7 +25,7 @@ def mark(img, nbs): # mark the array use (0, 1, 2)
 
 @jit(nopython=True) # trans index to r, c...
 def idx2rc(idx, acc):
-    rst = np.zeros((len(idx), len(acc)), dtype=np.int16)
+    rst = np.zeros((len(idx), len(acc)), dtype=np.int32)
     for i in range(len(idx)):
         for j in range(len(acc)):
             rst[i,j] = idx[i]//acc[j]


### PR DESCRIPTION
The current implementation is restricted to padded image size 32767 due to use of int16 for indexing, so I changed it to int32.

Maybe there should be a condition to use int32 only for bigger images? Didn't find out how to determine the size restriction inside this function.