### PR TITLE
Variable edge buf size. int64 coordinates.

### DIFF
--- a/sknw/sknw.py
+++ b/sknw/sknw.py
@@ -118,7 +118,7 @@ def parse_struc(img, nbs, acc, iso, ring, buf_size):
 # use nodes and edges build a networkx graph
 def build_graph(nodes, edges, multi=False, full=True):
     os = np.array([i.mean(axis=0) for i in nodes])
-    if full: os = os.round().astype(np.uint16)
+    if full: os = os.round().astype(np.uint32)
     graph = nx.MultiGraph() if multi else nx.Graph()
     for i in range(len(nodes)):
         graph.add_node(i, pts=nodes[i], o=os[i])

--- a/sknw/sknw.py
+++ b/sknw/sknw.py
@@ -135,7 +135,7 @@ def mark_node(ske):
     mark(buf, nbs)
     return buf
     
-def build_sknw(ske, buf_size=131072, multi=False, iso=True, ring=True, full=True):
+def build_sknw(ske, multi=False, iso=True, ring=True, full=True, buf_size=131072):
     buf = np.pad(ske, (1,1), mode='constant').astype(np.int64)
     nbs = neighbors(buf.shape)
     acc = np.cumprod((1,)+buf.shape[::-1][:-1])[::-1]

--- a/sknw/sknw.py
+++ b/sknw/sknw.py
@@ -127,7 +127,7 @@ def mark_node(ske):
     return buf
     
 def build_sknw(ske, buf_size=131072, multi=False, iso=True, ring=True, full=True):
-    buf = np.pad(ske, (1,1), mode='constant').astype(np.uint16)
+    buf = np.pad(ske, (1,1), mode='constant').astype(np.int64)
     nbs = neighbors(buf.shape)
     acc = np.cumprod((1,)+buf.shape[::-1][:-1])[::-1]
     mark(buf, nbs)

--- a/sknw/sknw.py
+++ b/sknw/sknw.py
@@ -25,7 +25,7 @@ def mark(img, nbs): # mark the array use (0, 1, 2)
 
 @jit(nopython=True) # trans index to r, c...
 def idx2rc(idx, acc):
-    rst = np.zeros((len(idx), len(acc)), dtype=np.int16)
+    rst = np.zeros((len(idx), len(acc)), dtype=np.int64)
     for i in range(len(idx)):
         for j in range(len(acc)):
             rst[i,j] = idx[i]//acc[j]
@@ -77,9 +77,9 @@ def trace(img, p, nbs, acc, buf):
     return (c1-10, c2-10, idx2rc(buf[:cur+1], acc))
    
 @jit(nopython=True) # parse the image then get the nodes and edges
-def parse_struc(img, nbs, acc, iso, ring):
+def parse_struc(img, nbs, acc, iso, ring, buf_size):
     img = img.ravel()
-    buf = np.zeros(131072, dtype=np.int64)
+    buf = np.zeros(buf_size, dtype=np.int64)
     num = 10
     nodes = []
     for p in range(len(img)):
@@ -126,12 +126,12 @@ def mark_node(ske):
     mark(buf, nbs)
     return buf
     
-def build_sknw(ske, multi=False, iso=True, ring=True, full=True):
+def build_sknw(ske, buf_size=131072, multi=False, iso=True, ring=True, full=True):
     buf = np.pad(ske, (1,1), mode='constant').astype(np.uint16)
     nbs = neighbors(buf.shape)
     acc = np.cumprod((1,)+buf.shape[::-1][:-1])[::-1]
     mark(buf, nbs)
-    nodes, edges = parse_struc(buf, nbs, acc, iso, ring)
+    nodes, edges = parse_struc(buf, nbs, acc, iso, ring, buf_size)
     return build_graph(nodes, edges, multi, full)
     
 # draw the graph


### PR DESCRIPTION
The edge buffer size is too small when dealing with large images.
So I added the option to make it user defined.

Also when converting large images where the x,y coordinates are larger than the max value of int16, the coordinates become invalid/capped to the max value of int16.
It is changed to int64.